### PR TITLE
main.qml: add context menu to app icons with "Add to favorites" option

### DIFF
--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -3,6 +3,7 @@ import QtQuick.Controls
 import QtQuick.Window
 import Cutie
 import Cutie.Wlc
+import Cutie.Store
 import Cutie.Desktopfileparser
 
 CutieWindow {
@@ -16,6 +17,18 @@ CutieWindow {
 
     // The model is initially undefined
     property var allAppsModel: null
+
+    CutieStore {
+        id: favoriteStore
+        appName: "cutie-launcher"
+        storeName: "favoriteItems"
+    }
+
+    function saveFavoriteItem(name) {
+        let data = favoriteStore.data;
+        data[name] = name;
+        favoriteStore.data = data;
+    }
 
     Component.onCompleted: {
         console.log("launcher - Window loaded, initializing all apps model...")
@@ -54,6 +67,7 @@ CutieWindow {
         }
 
         delegate: Item {
+            property alias menu: menu
             CutieButton {
                 id: appIconButton
                 width: launchAppGrid.cellWidth
@@ -65,6 +79,16 @@ CutieWindow {
                 background: null
 
                 onClicked: compositor.execApp(model.exec)
+                onPressAndHold: menu.open()
+            }
+
+            CutieMenu {
+                id: menu
+                width: window.width / 2
+                CutieMenuItem {
+                    text: qsTr("Add to favorites")
+                    onTriggered: saveFavoriteItem(model.name)
+                }
             }
 
             CutieLabel {

--- a/src/qml/main.qml
+++ b/src/qml/main.qml
@@ -33,6 +33,10 @@ CutieWindow {
     Component.onCompleted: {
         console.log("launcher - Window loaded, initializing all apps model...")
         allAppsModel = CutieDesktopFileParser.fetchAllEntriesModel()
+        console.log("launcher - Initialized with " + launchAppGrid.count + " apps")
+        Qt.callLater(() => {
+            console.log("launcher - initialized with " + launchAppGrid.count + " apps")
+        })
     }
 
     GridView {


### PR DESCRIPTION
- Introduced CutieMenu for each app icon, opened via press-and-hold
- Added CutieStore to persist favorite items under "favoriteItems"
- Implemented saveFavoriteItem() helper to handle favorite storage
- Updated imports to include Cutie.Store
![IMG_20251018_131837](https://github.com/user-attachments/assets/e352c5c3-4ff6-4127-ba4c-e21a59464f05)
